### PR TITLE
Add missing verb in quickstart

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -98,7 +98,7 @@ cd tutorials/quickstart/fluid-openfoam
 ```
 
 You can also run OpenFOAM in parallel: `./run.sh -parallel`.
-Before the simulation again, cleanup the results and temporary files using `./clean-tutorial.sh`.
+Before running the simulation again, cleanup the results and temporary files using `./clean-tutorial.sh`.
 
 In serial, the simulation should take less than a minute to compute (simulated time: 2.5s).
 


### PR DESCRIPTION
There was a verb missing in the section "Running the coupled simulation".